### PR TITLE
Fix incorrect link for I18n Project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A curated list of awesome projects, libraries, tools, fonts, and dev/design reso
 * [Azkar](https://github.com/AbdelrahmanBayoumi/Azkar-App) - Desktop Application shows notification for Azkar that pops-up every specific time, Calculating Muslim prayer times (for any location), and Morning and Nights Azkar with reminder.
 
 #### Javascript
-* [I18n](https://i18n.softvenue.net) - A Repository to provide arabic translation for technical terms.
+* [I18n](https://github.com/softvenue/i18n) - A Repository to provide arabic translation for technical terms.
 * [arabicString](https://github.com/ahmads/arabicString) - A Javascript library that extends the native String object with methods to help when dealing with Arabic strings for node and the browser.
 * [Arli](http://elkebirmed.github.io/arli/) - JavaScript tools for an Arabic development.
 * [bidiweb](https://github.com/hasenj/bidiweb) - Determine the base direction of paragraphs and adjust them accordingly.


### PR DESCRIPTION
This PR updates the link for the I18n project to point directly to the GitHub repository. 

Fixes #57. 