### PR TITLE
Fix broken link for Ruby 3arabi - Comment out with note

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Data, databases and content related or useful to Arabic projects.
 * [Hsoub I/O](https://io.hsoub.com/) - The Arabic Reddit-like.
 * [informatic-ar](http://informatic-ar.com/) - Arabic content about programming concepts, algorithms, AI ..etc.
 
-* [Ruby 3arabi](https://ruby3arabi.herokuapp.com/) - Learn Ruby in Arabic.
+<!-- * [Ruby 3arabi](https://ruby3arabi.herokuapp.com/) - Learn Ruby in Arabic. (Temporarily commented out--Link is broken) -->
 
 ## Communities
 * [LinuxAC](http://www.linuxac.org/) - Linux Arabic Community


### PR DESCRIPTION
The link to Ruby 3arabi in the README.md is no longer working. I've commented out the broken link and added a short note stating that the link is currently unavailable. This is a temporary fix until, hopefully, a valid link can be found. 

Fixes #63. 